### PR TITLE
修复StoreT中同步执行没有接收返回值的bug

### DIFF
--- a/Assets/Code/BDFramework/Core/UI(new)/UFlux@hotfix/StateManager/Store/StoreT.cs
+++ b/Assets/Code/BDFramework/Core/UI(new)/UFlux@hotfix/StateManager/Store/StoreT.cs
@@ -106,7 +106,7 @@ namespace BDFramework.UFlux.Store
                 var _newstate = await this.reducers.ExcuteAsync(action.ActionEnum, action.Params, oldState);
                 //再执行普通
                 if (_newstate == null)
-                    this.reducers.Excute(action.ActionEnum, action.Params, oldState);
+                    _newstate = this.reducers.Excute(action.ActionEnum, action.Params, oldState);
 
                 //素质三连
                 CacheCurrentState();


### PR DESCRIPTION
StoreT中的Dispatch方法，执行完同步模式中的普通部分后没有接收返回值，导致使用AddRecucer添加的同步Recucer无法正确返回State的值