### PR TITLE
OnFocus中默认调用Open不合理

### DIFF
--- a/Packages/com.popo.bdframework/Runtime/UI(UFlux)/@hotfix/View/Windows/AWindowProp.cs
+++ b/Packages/com.popo.bdframework/Runtime/UI(UFlux)/@hotfix/View/Windows/AWindowProp.cs
@@ -66,7 +66,7 @@ namespace BDFramework.UFlux
         /// </summary>
         public override void OnFocus()
         {
-            this.Open();
+            
         }
 
         #endregion


### PR DESCRIPTION
OnFocus中默认调用Open，导致关闭弹窗后页面刷新。所有页面都重写OnFocus太麻烦；