### PR TITLE
Fix a bug when getting a gzip header extra field with inflate()

### DIFF
--- a/HybridCLRData/LocalIl2CppData-WindowsEditor/il2cpp/external/zlib/inflate.c
+++ b/HybridCLRData/LocalIl2CppData-WindowsEditor/il2cpp/external/zlib/inflate.c
@@ -758,9 +758,10 @@ int flush;
                 copy = state->length;
                 if (copy > have) copy = have;
                 if (copy) {
+                    len = state->head->extra_len - state->length;
                     if (state->head != Z_NULL &&
-                        state->head->extra != Z_NULL) {
-                        len = state->head->extra_len - state->length;
+                        state->head->extra != Z_NULL &&
+                        len < state->head->extra_max) {
                         zmemcpy(state->head->extra + len, next,
                                 len + copy > state->head->extra_max ?
                                 state->head->extra_max - len : copy);


### PR DESCRIPTION
**Description**
This PR fixes a security vulnerability in inflate() that was cloned from lib but did not receive the security patch. The original issue was reported and fixed under https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1. This PR applies the same patch to eliminate the vulnerability.

References
https://nvd.nist.gov/vuln/detail/CVE-2022-37434
https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1